### PR TITLE
fix typo and add y gate

### DIFF
--- a/src/Core.ts
+++ b/src/Core.ts
@@ -1,6 +1,6 @@
 import { QuantumState, QuantumStateGenerator} from "./QuantumState";
 import { Qubit, QubitParameter } from "./Qubit";
-import { QuantmOperationTypes } from "./types";
+import { QuantumOperationTypes } from "./types";
 
 /**
  * Coreの初期化パラメータ
@@ -60,19 +60,20 @@ export class Core {
         });
     }
 
-    requestOperation(quantmOperationType: QuantmOperationTypes, ...qubits: Qubit[]) {
+    requestOperation(quantumOperationType: QuantumOperationTypes, ...qubits: Qubit[]) {
         // qubitsの順序で紐づいたQubitQuantumStateMapElementを取得する
         const qubitMapElements = qubits.map(qubit => this._lookupQubitQuantumStateMapElementFromQubit(qubit));
 
         // todo: 全ての量子操作に対してメソッドを個別に用意するのは冗長だが、switch文が伸びるのも読みづらいので、ある程度の粒度で分けたい
-        switch (quantmOperationType) {
-            case QuantmOperationTypes.X:
-            case QuantmOperationTypes.Z:
-            case QuantmOperationTypes.H:
+        switch (quantumOperationType) {
+            case QuantumOperationTypes.X:
+            case QuantumOperationTypes.Y:
+            case QuantumOperationTypes.Z:
+            case QuantumOperationTypes.H:
                 const mapElement = qubitMapElements[0]; // 単一量子ビットなので常にlength = 1
-                this._requestOperationSingleQubit(quantmOperationType, mapElement);
+                this._requestOperationSingleQubit(quantumOperationType, mapElement);
                 break;
-            case QuantmOperationTypes.CNOT:
+            case QuantumOperationTypes.CNOT:
                 const controlQubitMapElement = qubitMapElements[0];
                 const targetQubitMapElement = qubitMapElements[1];
                 // CNOT対象量子ビットが合成系ではない場合、先にマージして合成系のQuantumState化する
@@ -102,15 +103,18 @@ export class Core {
     /**
      * 単一量子ビットの量子操作
      */
-    _requestOperationSingleQubit(quantmOperationType: QuantmOperationTypes, mapElement: QubitQuantumStateMapElement) {
-        switch (quantmOperationType) {
-            case QuantmOperationTypes.X:
+    _requestOperationSingleQubit(quantumOperationType: QuantumOperationTypes, mapElement: QubitQuantumStateMapElement) {
+        switch (quantumOperationType) {
+            case QuantumOperationTypes.X:
                 mapElement.quantumState.x(mapElement.bitId);
                 break;
-            case QuantmOperationTypes.Z:
+            case QuantumOperationTypes.Y:
+                mapElement.quantumState.y(mapElement.bitId);
+                break;
+            case QuantumOperationTypes.Z:
                 mapElement.quantumState.z(mapElement.bitId);
                 break;
-            case QuantmOperationTypes.H:
+            case QuantumOperationTypes.H:
                 mapElement.quantumState.h(mapElement.bitId);
                 break;
             default:

--- a/src/QuantumState.ts
+++ b/src/QuantumState.ts
@@ -30,7 +30,7 @@ export abstract class QuantumState {
      * @param bitId 操作の対象となる量子ビットの識別ID
      */
     abstract x(bitId: number): void;
-    // abstract y(bitId: number): void;
+    abstract y(bitId: number): void;
     abstract z(bitId: number): void;
     abstract h(bitId: number): void;
     // abstract s(bitId: number): void;

--- a/src/QuantumStateImpl/QuantumStateJsqubits.ts
+++ b/src/QuantumStateImpl/QuantumStateJsqubits.ts
@@ -24,6 +24,10 @@ export class QuantumStateJsqubits extends QuantumState {
         this._qstate = this._qstate.X(bitId);
     }
 
+    y(bitId: number) {
+        this._qstate = this._qstate.Y(bitId);
+    }
+
     z(bitId: number) {
         this._qstate = this._qstate.Z(bitId);
     }

--- a/src/Qubit.ts
+++ b/src/Qubit.ts
@@ -1,6 +1,6 @@
 import { Core } from "./Core";
 import { QuantumStateParameter } from "./QuantumState";
-import { QuantmOperationTypes } from "./types";
+import { QuantumOperationTypes } from "./types";
 
 /**
  * Qubitの初期化パラメータ
@@ -26,15 +26,19 @@ export class Qubit {
     }
 
     x() {
-        Qubit._core.requestOperation(QuantmOperationTypes.X, this);
+        Qubit._core.requestOperation(QuantumOperationTypes.X, this);
+    }
+
+    y() {
+        Qubit._core.requestOperation(QuantumOperationTypes.Y, this);
     }
 
     z() {
-        Qubit._core.requestOperation(QuantmOperationTypes.Z, this);
+        Qubit._core.requestOperation(QuantumOperationTypes.Z, this);
     }
 
     h() {
-        Qubit._core.requestOperation(QuantmOperationTypes.H, this);
+        Qubit._core.requestOperation(QuantumOperationTypes.H, this);
     }
 
     /**
@@ -44,7 +48,7 @@ export class Qubit {
      * @param controlQubit 制御量子ビット
      */
     cnot(controlQubit: Qubit) {
-        Qubit._core.requestOperation(QuantmOperationTypes.CNOT, controlQubit, this);
+        Qubit._core.requestOperation(QuantumOperationTypes.CNOT, controlQubit, this);
 
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,9 @@
 /**
  * Plamanaがサポートする量子操作
  */
-export enum QuantmOperationTypes {
+export enum QuantumOperationTypes {
     X,
+    Y,
     Z,
     H,
     CNOT

--- a/typings/jsqubits.d.ts
+++ b/typings/jsqubits.d.ts
@@ -6,6 +6,7 @@ declare namespace jsqubits {
       multiply(amount: number | Complex): QState;
       tensorProduct(qstate: QState): QState;
       X(targetBits: number): QState;
+      Y(targetBits: number): QState;
       Z(targetBits: number): QState;
       hadamard(targetBits: number): QState;
       cnot(controlBits: number, targetBits: number): QState;


### PR DESCRIPTION
## 概要
Yゲートの追加を行います。
ついでにtypoを見つけてしまったのでQuantmOperationTypesをQuant**u**mOperationTypesへ修正します。

## 今後のTODO
テストは他のゲートと形式を合わせたほうが良さそうなので今後他のゲートと同時に実装しようと思うので今回はテストを実装していません。