### PR TITLE
fix README.md to exclude jsqubits.d.js dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,15 @@ jsqubits.d.tsを `git clone` し、ビルドした後、 `npm link` を実行し
 
 ```
 git clone git@github.com:m-qgame/pramana-prototype.git
-npm link jsqubits.d.ts
 npm install
 npm run build
+```
+
+## テスト方法
+ビルド方法のnpm installまで完了している必要がある。
+
+```
+npm run test
 ```
 
 ## 支援


### PR DESCRIPTION
# 概要
最新のmasterではjsqubits.d.tsを取り込んでおり、外部から持ってきてlinkを張る必要がないが、それがREADME.mdに反映されていなかったので修正した。

また、同時にUnitTestを実行するコマンドも追記した。


@kamakiri01 内容の確認おねがいします。