### PR TITLE
use lint script when test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc -p ./",
     "build:example": "tsc -p ./example",
     "copy": "cp-cli ./node_modules/jsqubits.d.ts/jsqubits.d.ts ./typings/jsqubits.d.ts",
-    "test": "npm run build && npm run test:build && npm run test:jest",
+    "test": "npm run build && npm run test:build && npm run test:jest && npm run lint",
     "test:build": "tsc -p ./spec",
     "test:jest": "jest",
     "lint": "npm run lint:src && npm run lint:spec",

--- a/spec/src/QubitSpec.ts
+++ b/spec/src/QubitSpec.ts
@@ -17,5 +17,5 @@ describe("test Qubit", () => {
         const qubit = new q.Qubit({ value: "|0>" });
         expect(qubit.toString()).toBe("|0>");
         done();
-    })
+    });
   });

--- a/tslint.json
+++ b/tslint.json
@@ -26,6 +26,7 @@
         "singleline": "never"
       }],
       "no-shadowed-variable": false,
-      "curly": false
+      "curly": false,
+      "max-classes-per-file": true
     }
 }


### PR DESCRIPTION
`npm run test` 実行時にlintが実行されていなかったため、実行されるようにします。