### PR TITLE
modify size of tests and name

### DIFF
--- a/spec/src/QubitSpec.ts
+++ b/spec/src/QubitSpec.ts
@@ -8,9 +8,11 @@ describe("test Qubit", () => {
         q.Qubit._core = core;
     });
 
-    it("initialize", (done: any) => {
-        const qubit = new q.Qubit({ value: "|0>" });
-        done();
+    describe("new", () => {
+        it("will finish without throwing Error", (done: any) => {
+            const qubit = new q.Qubit({ value: "|0>" });
+            done();
+        });
     });
 
     describe("#toString", () => {


### PR DESCRIPTION
# 概要

テストの粒度と命名規則を変更した。
各テストを小さくして、またメソッドごとにdescribeで束ねた。
