### PR TITLE
add toffoli gate

### DIFF
--- a/src/Qubit.ts
+++ b/src/Qubit.ts
@@ -146,6 +146,10 @@ export class Qubit {
         Qubit._core.requestRotateOperation(QuantumOperationTypes.ROTATEZ, angle, this);
     }
 
+    toffoli(controlQubit0: Qubit, controlQubit1: Qubit) {
+        Qubit._core.requestOperation(QuantumOperationTypes.TOFFOLI, controlQubit0, controlQubit1, this);
+    }
+
     /**
      * 量子ビットをZ基底で測定する
      * 返り値には0または1状態の測定結果が入る

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -1,0 +1,34 @@
+import { QuantumState } from "@qramana/qramana-common-types";
+
+/**
+ * ユニバーサルゲートセットで構成可能な演算のセット
+ */
+
+ /**
+  * toffoliゲート
+  */
+ export function toffoli(quantumState: QuantumState, controlBitId0: number, controlBitId1: number, targetBitId: number) {
+    quantumState.t(controlBitId1);
+    quantumState.h(targetBitId);
+    quantumState.t(targetBitId);
+    quantumState.cnot(controlBitId1, targetBitId);
+    t_dag(quantumState, targetBitId);
+    quantumState.cnot(controlBitId1, targetBitId);
+    quantumState.cnot(controlBitId0, controlBitId1);
+    t_dag(quantumState, controlBitId1);
+    quantumState.cnot(controlBitId1, targetBitId);
+    quantumState.t(targetBitId);
+    quantumState.cnot(controlBitId1, targetBitId);
+    quantumState.cnot(controlBitId0, controlBitId1);
+    quantumState.cnot(controlBitId0, targetBitId);
+    t_dag(quantumState, targetBitId);
+    quantumState.cnot(controlBitId0, targetBitId);
+    quantumState.t(controlBitId0);
+    quantumState.h(targetBitId);
+}
+
+ function t_dag(quantumState: QuantumState, bitId: number) {
+    quantumState.t(bitId);
+    quantumState.t(bitId);
+    quantumState.t(bitId);
+}

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -7,7 +7,7 @@ import { QuantumState } from "@qramana/qramana-common-types";
  /**
   * toffoliゲート
   */
- export function toffoli(quantumState: QuantumState, controlBitId0: number, controlBitId1: number, targetBitId: number) {
+export function toffoli(quantumState: QuantumState, controlBitId0: number, controlBitId1: number, targetBitId: number) {
     quantumState.t(controlBitId1);
     quantumState.h(targetBitId);
     quantumState.t(targetBitId);
@@ -27,7 +27,7 @@ import { QuantumState } from "@qramana/qramana-common-types";
     quantumState.h(targetBitId);
 }
 
- function t_dag(quantumState: QuantumState, bitId: number) {
+function t_dag(quantumState: QuantumState, bitId: number) {
     quantumState.t(bitId);
     quantumState.t(bitId);
     quantumState.t(bitId);

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,5 +14,6 @@ export enum QuantumOperationTypes {
     CONTROLLED_Z,
     ROTATEX,
     ROTATEY,
-    ROTATEZ
+    ROTATEZ,
+    TOFFOLI
 }


### PR DESCRIPTION
## Purpose
Qubit#toffoli を追加します。

## Approach
QuantumStateの共通インターフェイスにtoffoli実装を要求しないために、既存ゲートによる演算の合成として実装しています。
そのため、合成を記述するためのmethodsモジュールを追加しています。
