### PR TITLE
Remove `sudo: false` to use Linux infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ os:
 - windows
 - linux
 dist: bionic
-sudo: false
 script:
 - npm install
 - npm test


### PR DESCRIPTION
## Purpose

- To use Linux infrastructure instead of Container-based infrastructure in Travis CI

## Approach

- Remove `sudo: false`
    - It was added by me...😇

#### Open Questions and Pre-Merge TODOs
- Nothing

## Learning

- Travis CI requires to remove `sudo: false` option to move into Linux infrastructure. See also:
    - [Upcoming Required Linux Infrastructure Migration](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
- The official document says that Container-based infrastructure has been fully deprecated
    - https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure


#### Blog Posts
- Nothing
